### PR TITLE
Added label 'for' attributes on form fields

### DIFF
--- a/prototypes/census-disco/find-data/index.html
+++ b/prototypes/census-disco/find-data/index.html
@@ -45,64 +45,62 @@
         <div class="col-wrap">
             <div class="col col--md-one col--lg-one">
                 <h2>Select dimensions</h2>
-                <input type="checkbox" >
-                <label class="container">Age
-
+                <input type="checkbox" id="age">
+                <label class="container" for="age">Age
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">National level
 
+                <input type="checkbox" id="national_level">
+                  <label class="container" for="national_level">National level
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Counties and regions
 
+                  <input type="checkbox" id="counties">
+                  <label class="container" for="counties">Counties and regions
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Local authorities
 
+                  <input type="checkbox" id="local_auth">
+                  <label class="container" for="local_auth">Local authorities
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Small areas
 
+                  <input type="checkbox" id="small_areas">
+                  <label class="container" for="small_areas">Small areas
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Sex
 
+                  <input type="checkbox" id="sex">
+                  <label class="container" for="sex">Sex
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Ethnicity
 
+                  <input type="checkbox" id="ethnicity">
+                  <label class="container" for="ethnicity">Ethnicity
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Employment status
-
+                  <input type="checkbox" id="employment_status">
+                  <label class="container" for="employment_status">Employment status
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">Number of rooms
 
+                  <input type="checkbox" id="number_of_rooms">
+                  <label class="container" for="number_of_rooms">Number of rooms
                     <span class="checkmark"></span>
                   </label>
-                  <input type="checkbox" >
-                  <label class="container">etc
-                    
+
+                  <input type="checkbox" id="etc">
+                  <label class="container" for="etc">etc
                     <span class="checkmark"></span>
                   </label>
             </div>
             <div class="col col--md-one col--lg-one">
                 <h2>Select topics</h2>
-                <input type="radio" checked="checked" name="age" value="30"> All
-                <input type="radio" name="age" value="60"> Census
-                <input type="radio" name="age" value="100"> Employment  
-                <input type="radio" name="age" value="100"> Economy  
-                <input type="radio" name="age" value="100"> etc 
+                <input type="radio" checked="checked" name="topics" value="all" id="topic_all"> <label for="topic_all">All</label>
+                <input type="radio" name="topics" value="census" id="topic_census"> <label for="topic_census">Census</label>
+                <input type="radio" name="topics" value="employment" id="topic_employment"> <label for="topic_employment">Employment</label>
+                <input type="radio" name="topics" value="economy" id="topic_economy"> <label for="topic_economy">Economy</label>
+                <input type="radio" name="topics" value="etc" id="topic_etc"> <label for="topic_etc">etc</label>
             </div>
 
         </div>


### PR DESCRIPTION
### Rationale:
Minor amends to the form field attributes to improve the clickable areas for any inputs.

### Changes
- added for="[id_value]" and id="[id_value]" on checkbox labels
- added for="[id_value]" and id="[id_value]" on radio inputs and amended the name and value attributes.

### How to test
- check that the label text now checks the checkboxes or radio buttons on /prototypes/census-disco/find-data/